### PR TITLE
Move thread choosing logic to callback closure

### DIFF
--- a/Polyglot/Polyglot.swift
+++ b/Polyglot/Polyglot.swift
@@ -170,9 +170,7 @@ public class Polyglot {
                 translation = self.translationFromXML(xmlString)
 
                 defer {
-                    dispatch_async(dispatch_get_main_queue()) {
-                        callback(translation: translation)
-                    }   
+                    callback(translation: translation)
                 }
             }
             task.resume()

--- a/Polyglot/Polyglot.swift
+++ b/Polyglot/Polyglot.swift
@@ -138,7 +138,8 @@ public class Polyglot {
     }
 
     /**
-        Translates a given piece of text.
+        Translates a given piece of text asynchronously. Switch to the main thread within the callback
+        if you want to update your UI by using `dispatch_async(dispatch_get_main_queue()) { /* code */ }`.
 
         - parameter text: The text to translate.
         - parameter callback: The code to be executed once the translation has completed.
@@ -171,7 +172,7 @@ public class Polyglot {
                 defer {
                     dispatch_async(dispatch_get_main_queue()) {
                         callback(translation: translation)
-                    }
+                    }   
                 }
             }
             task.resume()

--- a/PolyglotTests/PolyglotTests.swift
+++ b/PolyglotTests/PolyglotTests.swift
@@ -91,8 +91,10 @@ class PolyglotTests: XCTestCase {
 
         let polyglot: Polyglot = Polyglot(clientId: "myClientId", clientSecret: "myClientSecret")
         polyglot.translate("Ik weet het niet") { translation in
-            XCTAssertEqual(translation, "I don't know")
-            expectation.fulfill()
+            dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                XCTAssertEqual(translation, "I don't know")
+                expectation.fulfill()
+            })
         }
 
         waitForExpectationsWithTimeout(1, handler: nil)


### PR DESCRIPTION
Sorry for forgetting this earlier but better late than never!

Here's the follow-up on #16 where we decided to split the PR into two parts as this part seemed to **break tests on Travis** (tests were still passing on my local machine). Please refer to the commit message in a078ea90ef7fd8a7f7baaed2297241f44a8defaa for the rationale of this change.
